### PR TITLE
Improve working with big raster files needs lot of ram

### DIFF
--- a/raster/.vscode/.ropeproject/config.py
+++ b/raster/.vscode/.ropeproject/config.py
@@ -1,0 +1,114 @@
+# The default ``config.py``
+# flake8: noqa
+
+
+def set_prefs(prefs):
+    """This function is called before opening the project"""
+
+    # Specify which files and folders to ignore in the project.
+    # Changes to ignored resources are not added to the history and
+    # VCSs.  Also they are not returned in `Project.get_files()`.
+    # Note that ``?`` and ``*`` match all characters but slashes.
+    # '*.pyc': matches 'test.pyc' and 'pkg/test.pyc'
+    # 'mod*.pyc': matches 'test/mod1.pyc' but not 'mod/1.pyc'
+    # '.svn': matches 'pkg/.svn' and all of its children
+    # 'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
+    # 'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
+    prefs['ignored_resources'] = ['*.pyc', '*~', '.ropeproject',
+                                  '.hg', '.svn', '_svn', '.git', '.tox']
+
+    # Specifies which files should be considered python files.  It is
+    # useful when you have scripts inside your project.  Only files
+    # ending with ``.py`` are considered to be python files by
+    # default.
+    # prefs['python_files'] = ['*.py']
+
+    # Custom source folders:  By default rope searches the project
+    # for finding source folders (folders that should be searched
+    # for finding modules).  You can add paths to that list.  Note
+    # that rope guesses project source folders correctly most of the
+    # time; use this if you have any problems.
+    # The folders should be relative to project root and use '/' for
+    # separating folders regardless of the platform rope is running on.
+    # 'src/my_source_folder' for instance.
+    # prefs.add('source_folders', 'src')
+
+    # You can extend python path for looking up modules
+    # prefs.add('python_path', '~/python/')
+
+    # Should rope save object information or not.
+    prefs['save_objectdb'] = True
+    prefs['compress_objectdb'] = False
+
+    # If `True`, rope analyzes each module when it is being saved.
+    prefs['automatic_soa'] = True
+    # The depth of calls to follow in static object analysis
+    prefs['soa_followed_calls'] = 0
+
+    # If `False` when running modules or unit tests "dynamic object
+    # analysis" is turned off.  This makes them much faster.
+    prefs['perform_doa'] = True
+
+    # Rope can check the validity of its object DB when running.
+    prefs['validate_objectdb'] = True
+
+    # How many undos to hold?
+    prefs['max_history_items'] = 32
+
+    # Shows whether to save history across sessions.
+    prefs['save_history'] = True
+    prefs['compress_history'] = False
+
+    # Set the number spaces used for indenting.  According to
+    # :PEP:`8`, it is best to use 4 spaces.  Since most of rope's
+    # unit-tests use 4 spaces it is more reliable, too.
+    prefs['indent_size'] = 4
+
+    # Builtin and c-extension modules that are allowed to be imported
+    # and inspected by rope.
+    prefs['extension_modules'] = []
+
+    # Add all standard c-extensions to extension_modules list.
+    prefs['import_dynload_stdmods'] = True
+
+    # If `True` modules with syntax errors are considered to be empty.
+    # The default value is `False`; When `False` syntax errors raise
+    # `rope.base.exceptions.ModuleSyntaxError` exception.
+    prefs['ignore_syntax_errors'] = False
+
+    # If `True`, rope ignores unresolvable imports.  Otherwise, they
+    # appear in the importing namespace.
+    prefs['ignore_bad_imports'] = False
+
+    # If `True`, rope will insert new module imports as
+    # `from <package> import <module>` by default.
+    prefs['prefer_module_from_imports'] = False
+
+    # If `True`, rope will transform a comma list of imports into
+    # multiple separate import statements when organizing
+    # imports.
+    prefs['split_imports'] = False
+
+    # If `True`, rope will remove all top-level import statements and
+    # reinsert them at the top of the module when making changes.
+    prefs['pull_imports_to_top'] = True
+
+    # If `True`, rope will sort imports alphabetically by module name instead
+    # of alphabetically by import statement, with from imports after normal
+    # imports.
+    prefs['sort_imports_alphabetically'] = False
+
+    # Location of implementation of
+    # rope.base.oi.type_hinting.interfaces.ITypeHintingFactory In general
+    # case, you don't have to change this value, unless you're an rope expert.
+    # Change this value to inject you own implementations of interfaces
+    # listed in module rope.base.oi.type_hinting.providers.interfaces
+    # For example, you can add you own providers for Django Models, or disable
+    # the search type-hinting in a class hierarchy, etc.
+    prefs['type_hinting_factory'] = (
+        'rope.base.oi.type_hinting.factory.default_type_hinting_factory')
+
+
+def project_opened(project):
+    """This function is called after opening the project"""
+    # Do whatever you like here!

--- a/raster/admin.py
+++ b/raster/admin.py
@@ -29,10 +29,6 @@ class RasterLayerMetadataInline(admin.TabularInline):
     def has_add_permission(self, request, obj=None):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-
 class RasterLayerParseStatusInline(admin.TabularInline):
     model = RasterLayerParseStatus
     extra = 0
@@ -40,10 +36,6 @@ class RasterLayerParseStatusInline(admin.TabularInline):
 
     def has_add_permission(self, request, obj=None):
         return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
 
 class RasterLayerBandMetadataInline(admin.TabularInline):
     model = RasterLayerBandMetadata
@@ -55,10 +47,6 @@ class RasterLayerBandMetadataInline(admin.TabularInline):
 
     def has_add_permission(self, request, obj=None):
         return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
 
 class RasterLayerReprojectedInline(admin.TabularInline):
     model = RasterLayerReprojected
@@ -141,9 +129,6 @@ class RasterLayerMetadataModelAdmin(admin.ModelAdmin):
     def has_add_permission(self, request, obj=None):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
 
 class RasterTileModelAdmin(admin.ModelAdmin):
     readonly_fields = (
@@ -151,9 +136,6 @@ class RasterTileModelAdmin(admin.ModelAdmin):
     )
 
     def has_add_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
         return False
 
 

--- a/raster/const.py
+++ b/raster/const.py
@@ -6,6 +6,7 @@ IMG_ENHANCEMENTS = {
     'enhance_brightness': ImageEnhance.Brightness,
     'enhance_sharpness': ImageEnhance.Sharpness,
 }
+
 IMG_FORMATS = {'png': ('PNG', 'image/png'), 'jpg': ('JPEG', 'image/jpeg'), 'tif': ('TIFF', 'image/tiff')}
 EXPORT_MAX_PIXELS = 10000 * 10000
 MAX_EXPORT_NAME_LENGTH = 100

--- a/raster/tasks.py
+++ b/raster/tasks.py
@@ -1,5 +1,6 @@
 import shutil
 import traceback
+from asgiref.sync import sync_to_async
 
 from celery import group, shared_task
 

--- a/raster/tiles/parser.py
+++ b/raster/tiles/parser.py
@@ -136,6 +136,7 @@ class RasterLayerParser(object):
             self.dataset = None
             for match in matches:
                 try:
+                     # change to vsis3 or vsimem
                     self.dataset = GDALRaster(match)
                     break
                 except GDALException:
@@ -145,6 +146,7 @@ class RasterLayerParser(object):
             if not self.dataset:
                 raise RasterException('Could not open rasterfile.')
         else:
+            # change to vsis3 or vsimem
             self.dataset = GDALRaster(filepath)
 
         # Override srid if provided
@@ -341,77 +343,80 @@ class RasterLayerParser(object):
 
         # Compute quadrant bounds and create destination file
         bounds = utils.tile_bounds(indexrange[0], indexrange[1], zoom)
+        dest_file_name = os.path.join('/vsimem/', '{}.tif'.format(uuid.uuid4()))
 
-        try:
-            dest_file_name = os.path.join(self.tmpdir, '{}.tif'.format(uuid.uuid4()))
+        # Snap dataset to the quadrant
+        snapped_dataset = self.dataset.warp({
+            'name': dest_file_name,
+            'origin': [bounds[0], bounds[3]],
+            'scale': [tilescale, -tilescale],
+            'width': (indexrange[2] - indexrange[0] + 1) * self.tilesize,
+            'height': (indexrange[3] - indexrange[1] + 1) * self.tilesize,
+        })
 
-            # Snap dataset to the quadrant
-            snapped_dataset = self.dataset.warp({
-                'name': dest_file_name,
-                'origin': [bounds[0], bounds[3]],
-                'scale': [tilescale, -tilescale],
-                'width': (indexrange[2] - indexrange[0] + 1) * self.tilesize,
-                'height': (indexrange[3] - indexrange[1] + 1) * self.tilesize,
-            })
+        # Create all tiles in this quadrant in batches
+        batch = []
+        for tilex in range(indexrange[0], indexrange[2] + 1):
+            for tiley in range(indexrange[1], indexrange[3] + 1):
+                # Calculate raster tile origin
+                bounds = utils.tile_bounds(tilex, tiley, zoom)
 
-            # Create all tiles in this quadrant in batches
-            batch = []
-            for tilex in range(indexrange[0], indexrange[2] + 1):
-                for tiley in range(indexrange[1], indexrange[3] + 1):
-                    # Calculate raster tile origin
-                    bounds = utils.tile_bounds(tilex, tiley, zoom)
+                # Construct band data arrays
+                pixeloffset = (
+                    (tilex - indexrange[0]) * self.tilesize,
+                    (tiley - indexrange[1]) * self.tilesize
+                )
 
-                    # Construct band data arrays
-                    pixeloffset = (
-                        (tilex - indexrange[0]) * self.tilesize,
-                        (tiley - indexrange[1]) * self.tilesize
+                band_data = [
+                    {
+                        'data': band.data(offset=pixeloffset, size=(self.tilesize, self.tilesize)),
+                        'nodata_value': band.nodata_value
+                    } for band in snapped_dataset.bands
+                ]
+
+                # Ignore tile if its only nodata.
+                if all([numpy.all(dat['data'] == dat['nodata_value']) for dat in band_data]):
+                    continue
+
+                # Add tile data to histogram
+                if zoom == self.max_zoom:
+                    self.push_histogram(band_data)
+
+                # Warp source raster into this tile (in memory)
+                dest = GDALRaster({
+                    'width': self.tilesize,
+                    'height': self.tilesize,
+                    'origin': [bounds[0], bounds[3]],
+                    'scale': [tilescale, -tilescale],
+                    'srid': WEB_MERCATOR_SRID,
+                    'datatype': snapped_dataset.bands[0].datatype(),
+                    'bands': band_data,
+                })
+
+                # Store tile in batch array
+                batch.append(
+                    RasterTile(
+                        rast=dest,
+                        rasterlayer_id=self.rasterlayer.id,
+                        tilex=tilex,
+                        tiley=tiley,
+                        tilez=zoom
                     )
+                )
 
-                    band_data = [
-                        {
-                            'data': band.data(offset=pixeloffset, size=(self.tilesize, self.tilesize)),
-                            'nodata_value': band.nodata_value
-                        } for band in snapped_dataset.bands
-                    ]
+                # Commit batch to database and reset it
+                # if len(batch) == self.batch_step_size:
+                #     RasterTile.objects.bulk_create(batch)
+                #     batch = []
 
-                    # Ignore tile if its only nodata.
-                    if all([numpy.all(dat['data'] == dat['nodata_value']) for dat in band_data]):
-                        continue
+            if len(batch):
+                RasterTile.objects.bulk_create(batch, self.batch_step_size)
+                # print("{0}, batch# written: {1} for zoom: {2}".format(self.rasterlayer.id, len(batch), zoom))
+                batch = [] 
 
-                    # Add tile data to histogram
-                    if zoom == self.max_zoom:
-                        self.push_histogram(band_data)
-
-                    # Warp source raster into this tile (in memory)
-                    dest = GDALRaster({
-                        'width': self.tilesize,
-                        'height': self.tilesize,
-                        'origin': [bounds[0], bounds[3]],
-                        'scale': [tilescale, -tilescale],
-                        'srid': WEB_MERCATOR_SRID,
-                        'datatype': snapped_dataset.bands[0].datatype(),
-                        'bands': band_data,
-                    })
-
-                    # Store tile in batch array
-                    batch.append(
-                        RasterTile(
-                            rast=dest,
-                            rasterlayer_id=self.rasterlayer.id,
-                            tilex=tilex,
-                            tiley=tiley,
-                            tilez=zoom
-                        )
-                    )
-
-                    # Commit batch to database and reset it
-                    if len(batch):
-                        RasterTile.objects.bulk_create(batch, self.batch_step_size)
-                        batch = []
-        finally:
-            # Remove quadrant raster tempfile.
-            snapped_dataset = None
-            os.remove(dest_file_name)
+        # Remove quadrant raster tempfile.
+        snapped_dataset = None
+        # os.remove(dest_file_name)
 
     def push_histogram(self, data):
         """
@@ -440,7 +445,16 @@ class RasterLayerParser(object):
             'Successfully finished parsing raster',
             status=self.rasterlayer.parsestatus.FINISHED
         )
+
+        if self.rasterlayer.rasterfile.name:
+            tmpFile = os.path.join("/tmp/", os.path.basename(self.rasterlayer.rasterfile.name))
+            if tmpFile:
+                if os.path.exists(tmpFile):
+                    print("tmpfile to delete: " + tmpFile)
+                    os.remove(tmpFile)
+
         rasterlayers_parser_ended.send(sender=self.rasterlayer.__class__, instance=self.rasterlayer)
+    
 
     def compute_max_zoom(self):
         """


### PR DESCRIPTION
## Problem statement
### Big raster files in AWS  issues
* /tmp storage gets full with  20GB docker image limit
* it takes 7 /8 hours to process a 10GB Sentinel 2 tif 

### Query in parser.py to be written to db , is to big
in process_quadrant bulk_create results in to big query to be written, query string is just to big and result in crash.

### Can not remove raster layers from django admin

## Changes 
* GDAL vsimem for creating tiles in memory (and not in tmp files) in parser.py
* add removal of (self.rasterlayer.rasterfile.name) when in /tmp to send_success_signal
* added  to .bulk_create  second parameter  with max batch_size so that query to be written to db is not to big, is new since Django (X?). 
```
            # Commit batch to database and reset it
                # if len(batch) == self.batch_step_size:
                #     RasterTile.objects.bulk_create(batch)
                #     batch = []

            if len(batch):
                RasterTile.objects.bulk_create(batch, self.batch_step_size)
                # print("{0}, batch# written: {1} for zoom: {2}".format(self.rasterlayer.id, len(batch), zoom))
                batch = [] 
```
* removed from admin.py the following:
```
            def has_delete_permission(self, request, obj=None):
                return False
```

## Solves
* processing time reduced to 1.5 hours of processing  for 100GB  S2 raster files (when using 16GB RAM and 2 CPU)
* less tmp files created 
* no "query string buffer  is to big" errors from postgres

## Drawbacks using vsimem:
* vsimem needs a lot of more memory to process files , when not enough RAM celery crashes
* vsimem seems only to work nice with celery pool solo with big raster files

## Drawback using max batch-size parameter in bulkcreate:
will not work with old Django versions .

